### PR TITLE
Implementation of "clear" button for clearing filters

### DIFF
--- a/src/app/configurable-appliance/components/config-app/story-list/story-list.component.html
+++ b/src/app/configurable-appliance/components/config-app/story-list/story-list.component.html
@@ -192,6 +192,7 @@
 							<button pButton pRipple icon="pi pi-plus" class="p-button-rounded p-button-secondary mr-2" (click)="addWord(story)"></button>
 							 <button pButton pRipple icon="pi pi-pencil" class="p-button-rounded p-button-success mr-2" (click)="editStory(story)"></button>
 							<button pButton pRipple icon="pi pi-trash" class="p-button-rounded p-button-danger mr-2" (click)="deleteProduct(story)"></button>
+							<button (click)="clearFilters()" class="p-button p-button-secondary" type="button">Clear Filters</button>
 
                         </td>
                     </tr>

--- a/src/app/configurable-appliance/components/config-app/story-list/story-list.component.ts
+++ b/src/app/configurable-appliance/components/config-app/story-list/story-list.component.ts
@@ -169,7 +169,7 @@ export class StoryList implements OnInit {
     }
 
     clear(table: Table) {
-        table.clear();
+        table.dataTable.clear();
     }
 
     openWordList(collectionId: string) {

--- a/src/app/configurable-appliance/components/config-app/word-sentence/word-sentence.component.html
+++ b/src/app/configurable-appliance/components/config-app/word-sentence/word-sentence.component.html
@@ -231,6 +231,7 @@
                             (click)="editContent(wordAndSentence)"
                           ></button>
 							<button pButton pRipple icon="pi pi-trash" class="p-button-rounded p-button-danger" (click)="deleteWorkAndSentence(wordAndSentence)"></button>
+							<button (click)="clearFilters()" class="p-button p-button-secondary" type="button">Clear Filters</button>
                         </td>
                     </tr>
                 </ng-template>

--- a/src/app/configurable-appliance/components/config-app/word-sentence/word-sentence.component.ts
+++ b/src/app/configurable-appliance/components/config-app/word-sentence/word-sentence.component.ts
@@ -199,7 +199,7 @@ export class WordSentenceComponent implements AfterViewInit {
     }
   
     clear(table: Table) {
-        table.clear();
+        table.dataTable.clear();
     }
 
   toggleEdit(wordAndSentence: any): void {


### PR DESCRIPTION
This pull request, labeled #11, introduces a feature that enables a "Clear" button functionality within both the Story List and Word Sentence components. This enhancement empowers users to effortlessly reset any filters they have applied.